### PR TITLE
Add cool-birds-ring to Backstage Software Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,12 +1,9 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: "cool-birds-ring"
-  description: "Manages uploads of bird song recordings"
-  annotations:
-    github.com/project-slug: backstage-demos/cool-birds-ring
-    backstage.io/techdocs-ref: dir:.
-spec:
-  type: website
-  lifecycle: experimental
-  owner: "team-a"
+  kind: Component
+  metadata:
+    name: cool-birds-ring
+  spec:
+    type: service
+    lifecycle: experimental
+    owner: backstage-demos/test-team
+    system: example


### PR DESCRIPTION

## TL;DR

This pull request registers cool-birds-ring, as a component in our Backstage Software Catalog. 
It lists our team, backstage-demos/test-team, as the owners of this component.
After this file has merged, you can view this component in Backstage Software Catalog here: → http://localhost/catalog

## What is Backstage?

[Backstage](https://backstage.io/) is an open platform for building developer portals. Powered by a centralized 
software catalog, Backstage restores order to your microservices and infrastructure and enables your product teams 
to ship high-quality code quickly without compromising autonomy.

Backstage unifies all your infrastructure tooling, services, and documentation to create a streamlined development environment from end to end.

[![What is Backstage? (Explainer Video)](https://img.youtube.com/vi/85TQEpNCaU0/hqdefault.jpg)](https://youtu.be/85TQEpNCaU0)
